### PR TITLE
CI の cargo コマンドに --locked フラグを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release
+      - run: cargo build --release --locked
       - uses: actions/upload-artifact@v7
         with:
           name: csvr-macos

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --locked -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - run: cargo test --locked


### PR DESCRIPTION
## 変更の概要
CI の cargo build / clippy / test に `--locked` フラグを追加し、`Cargo.toml` と `Cargo.lock` の不一致を検知できるようにします。

## 主な変更点
- `build.yml`: `cargo build --release` → `cargo build --release --locked`
- `lint.yml`: `cargo clippy` → `cargo clippy --locked`
- `test.yml`: `cargo test` → `cargo test --locked`

## 変更の背景
- pnpm の `--frozen-lockfile` に相当する安全ネットが未設定だった
- Renovate による依存更新や手動の `Cargo.toml` 編集時に、`Cargo.lock` の更新漏れを CI で検知できるようにする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 継続的インテグレーション(CI)ワークフローの安定性を強化しました。ビルド、リント、テスト処理において依存関係バージョンの固定化を実装し、より確実で再現可能なビルド環境を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->