### PR TITLE
reusable workflow の permissions をワークフローレベルに移動

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,15 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, ready_for_review, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
 jobs:
   claude-review:
     if: |
       contains(github.event.pull_request.labels.*.name, 'claude-review')
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
     uses: rysk-tanaka/workflows/.github/workflows/claude-code-review.yml@main
     with:
       track_progress: ${{ github.event.action != 'labeled' }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,13 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+  id-token: write
+
 jobs:
   claude:
     if: |
@@ -17,12 +24,6 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, '@claude ') || github.event.comment.body == '@claude')) ||
       (github.event_name == 'pull_request_review' && (contains(github.event.review.body, '@claude ') || github.event.review.body == '@claude')) ||
       (github.event_name == 'issues' && ((contains(github.event.issue.body, '@claude ') || github.event.issue.body == '@claude') || (contains(github.event.issue.title, '@claude ') || github.event.issue.title == '@claude')))
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      actions: read
-      id-token: write
     uses: rysk-tanaka/workflows/.github/workflows/claude.yml@main
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## 変更の概要

reusable workflow を呼び出す `claude-code-review.yml` と `claude.yml` で、`permissions` をジョブレベルからワークフローレベルに移動しました。

## 主な変更点

- `claude-code-review.yml`: `permissions` をジョブレベルからワークフローレベルに移動
- `claude.yml`: 同上

## 変更の背景

reusable workflow 移行（#27）の際に `permissions` がジョブレベルに残っていたため、GitHub Actions が reusable workflow の解決に失敗し、ワークフローが実行されない状態になっていました。
GitHub Actions では reusable workflow を `uses` で呼び出すジョブに `permissions` をジョブレベルで設定できないため、ワークフローレベルに移動する必要があります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub ActionsワークフローのCI/CD設定構造を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->